### PR TITLE
Rename docs command.

### DIFF
--- a/keymaps/sourcegraph-atom.cson
+++ b/keymaps/sourcegraph-atom.cson
@@ -9,4 +9,4 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-workspace':
   'alt-.': 'sourcegraph-atom:jump-to-definition'
-  'ctrl-alt-d' : 'sourcegraph-atom:docs-examples'
+  'ctrl-alt-d' : 'sourcegraph-atom:show-documentation-and-examples'

--- a/lib/sourcegraph-atom.coffee
+++ b/lib/sourcegraph-atom.coffee
@@ -153,7 +153,7 @@ module.exports =
 
     @commands = atom.commands.add 'atom-workspace',
       'sourcegraph-atom:jump-to-definition': => @jumpToDefinition()
-      'sourcegraph-atom:docs-examples': => @docsExamples()
+      'sourcegraph-atom:show-documentation-and-examples': => @docsExamples()
       'sourcegraph-atom:search-on-sourcegraph': => @searchOnSourcegraph()
 
     atom.workspace.addOpener (uri) ->

--- a/menus/sourcegraph-atom.cson
+++ b/menus/sourcegraph-atom.cson
@@ -6,8 +6,8 @@
       'command': 'sourcegraph-atom:jump-to-definition'
     },
     {
-      'label': 'See Documentation and Examples',
-      'command': 'sourcegraph-atom:docs-examples'
+      'label': 'Show Documentation and Examples',
+      'command': 'sourcegraph-atom:show-documentation-and-examples'
     }
   ]
 'menu': [


### PR DESCRIPTION
Atom uses internal command names as text in `ctrl+shift+p` list.

Fixes sourcegraph/sourcegraph-atom#9.