### PR TITLE
Update typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To develop the plugin:
 - `git clone` the repository into `~/.atom/Packages/sourcegraph` (lowercase `packages` on Mac), `npm install` and open in Atom.
 - Use <kbd>Cmd+Shift+P</kbd> to open the command pallette, and choose `Window: Reload` to reload the extension in the current Atom window.
 - Atom does some really bad things with respect to reopening the workspace, so `File` -> `Reopen Project` and `View` -> `Toggle Tree View` (<kbd>Cmd+\\</kbd>) are your friends here. Consider using a separate editor to make changes.
-- To release a new version, you MSUT update the following files:
+- To release a new version, you MUST update the following files:
   1. `CHANGELOG.md` (describe ALL changes)
   3. `lib/sourcegraph.js` (`VERSION` constant)
   4. `git commit -m "all: release v<THE VERSION>" && git push`


### PR DESCRIPTION
Just spotted this whilst reading through the docs [here](https://atom.io/packages/sourcegraph).  

Not 100% sure that updating the Github ReadMe updates the atom page or if you need to copy and paste this somewhere, but I'm guessing it would just update automatically?

Neglected updating the changelog or the version because there were no "functional" changes.